### PR TITLE
refactor: 기사 API 설계 개선 및 Swagger 문서화 강화

### DIFF
--- a/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/AdminController.java
+++ b/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
     private final ChangeUserStatusUseCase changeUserStatusUseCase;
     private final AdminDeleteUserUseCase adminDeleteUserUseCase;
     
-    @Operation(summary = "전체 사용자 조회", description = "관리자가 전체 사용자 목록을 조회합니다.")
+    @Operation(summary = "전체 사용자 조회", description = "관리자 전용 API. 전체 사용자(승객/기사/관리자) 목록을 조회합니다. 사용자 기본 정보를 포함합니다.")
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<List<AdminUserListResponse>>> getAllUsers(
             @RequestHeader("X-User-Role") String requestUserRole) {
@@ -48,7 +48,7 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.success(response, "전체 사용자 조회가 완료되었습니다."));
     }
     
-    @Operation(summary = "사용자 상세 조회", description = "관리자가 특정 사용자의 상세 정보를 조회합니다.")
+    @Operation(summary = "사용자 상세 조회", description = "관리자 전용 API. 특정 사용자(승객/기사/관리자)의 상세 정보를 조회합니다. 생성/수정 시간 포함.")
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<AdminUserDetailResponse>> getUserDetail(
             @RequestHeader("X-User-Role") String requestUserRole,
@@ -64,7 +64,7 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 상세 조회가 완료되었습니다."));
     }
     
-    @Operation(summary = "사용자 상태 변경", description = "관리자가 사용자의 활성/비활성 상태를 변경합니다.")
+    @Operation(summary = "사용자 상태 변경", description = "관리자 전용 API. 특정 사용자(승객/기사/관리자)의 활성/비활성 상태를 변경합니다. 정지/해제 처리에 사용.")
     @PatchMapping("/users/{userId}/status")
     public ResponseEntity<ApiResponse<ChangeUserStatusResponse>> changeUserStatus(
             @RequestHeader("X-User-Role") String requestUserRole,
@@ -82,7 +82,7 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 상태 변경이 완료되었습니다."));
     }
     
-    @Operation(summary = "사용자 삭제", description = "관리자가 사용자를 삭제 처리합니다.")
+    @Operation(summary = "사용자 삭제", description = "관리자 전용 API. 특정 사용자(승객/기사/관리자)를 삭제 처리합니다. 삭제 사유 필수, Soft Delete로 처리됩니다.")
     @PatchMapping("/users/{userId}/delete")
     public ResponseEntity<ApiResponse<DeleteUserResponse>> deleteUser(
             @RequestHeader("X-User-Role") String requestUserRole,

--- a/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/DriverController.java
+++ b/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/DriverController.java
@@ -30,7 +30,7 @@ public class DriverController {
     private final UpdateDriverProfileUseCase updateDriverProfileUseCase;
     private final UpdateDriverStatusUseCase updateDriverStatusUseCase;
     
-    @Operation(summary = "기사 프로필 조회", description = "특정 기사의 프로필 정보를 조회합니다.")
+    @Operation(summary = "기사 프로필 조회", description = "특정 기사의 프로필 정보(차량 정보, 온라인 상태 등)를 조회합니다. 모든 사용자가 조회 가능합니다.")
     @GetMapping("/{driverId}")
     public ResponseEntity<ApiResponse<DriverProfileResponse>> getDriverProfile(
             @PathVariable("driverId") String driverId) {
@@ -45,42 +45,38 @@ public class DriverController {
         return ResponseEntity.ok(ApiResponse.success(response, "기사 프로필 조회가 완료되었습니다."));
     }
     
-    @Operation(summary = "기사 프로필 수정", description = "기사의 프로필 정보(차량 정보)를 수정합니다.")
-    @PatchMapping("/{driverId}")
-    public ResponseEntity<ApiResponse<UpdateDriverProfileResponse>> updateDriverProfile(
-            @RequestHeader("X-User-UUID") String requestUserUuid,
-            @PathVariable("driverId") String driverId,
+    @Operation(summary = "내 프로필 수정", description = "현재 로그인된 기사의 차량 정보(차량번호, 차량종류, 차량색상)를 수정합니다. 기사 전용 API입니다.")
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UpdateDriverProfileResponse>> updateMyDriverProfile(
+            @RequestHeader("X-User-UUID") String userUuid,
             @Valid @RequestBody UpdateDriverProfileCommand command) {
         
-        log.debug("기사 프로필 수정 요청: requestUser={}, driverId={}", requestUserUuid, driverId);
+        log.debug("기사 프로필 수정 요청: userUuid={}", userUuid);
         
-        UUID requestUuid = UUID.fromString(requestUserUuid);
-        UUID driverUuid = UUID.fromString(driverId);
+        UUID requestUuid = UUID.fromString(userUuid);
         
-        UpdateDriverProfileResponse response = updateDriverProfileUseCase.execute(requestUuid, driverUuid, command);
+        UpdateDriverProfileResponse response = updateDriverProfileUseCase.execute(requestUuid, requestUuid, command);
         
-        log.debug("기사 프로필 수정 완료: driverId={}", driverId);
+        log.debug("기사 프로필 수정 완료: userUuid={}", userUuid);
         
-        return ResponseEntity.ok(ApiResponse.success(response, "기사 프로필 수정이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success(response, "내 프로필 수정이 완료되었습니다."));
     }
     
-    @Operation(summary = "기사 상태 변경", description = "기사의 온라인/오프라인 상태를 변경합니다.")
-    @PatchMapping("/{driverId}/status")
-    public ResponseEntity<ApiResponse<UpdateDriverStatusResponse>> updateDriverStatus(
-            @RequestHeader("X-User-UUID") String requestUserUuid,
-            @PathVariable("driverId") String driverId,
+    @Operation(summary = "내 상태 변경", description = "현재 로그인된 기사의 온라인/오프라인 상태를 변경합니다. 기사 전용 API로 배차 가능 상태를 조절합니다.")
+    @PatchMapping("/me/status")
+    public ResponseEntity<ApiResponse<UpdateDriverStatusResponse>> updateMyDriverStatus(
+            @RequestHeader("X-User-UUID") String userUuid,
             @Valid @RequestBody UpdateDriverStatusCommand command) {
         
-        log.debug("기사 상태 변경 요청: requestUser={}, driverId={}, status={}", 
-                requestUserUuid, driverId, command.getOnlineStatus());
+        log.debug("기사 상태 변경 요청: userUuid={}, status={}", 
+                userUuid, command.getOnlineStatus());
         
-        UUID requestUuid = UUID.fromString(requestUserUuid);
-        UUID driverUuid = UUID.fromString(driverId);
+        UUID requestUuid = UUID.fromString(userUuid);
         
-        UpdateDriverStatusResponse response = updateDriverStatusUseCase.execute(requestUuid, driverUuid, command);
+        UpdateDriverStatusResponse response = updateDriverStatusUseCase.execute(requestUuid, requestUuid, command);
         
-        log.debug("기사 상태 변경 완료: driverId={}, newStatus={}", driverId, response.getOnlineStatus());
+        log.debug("기사 상태 변경 완료: userUuid={}, newStatus={}", userUuid, response.getOnlineStatus());
         
-        return ResponseEntity.ok(ApiResponse.success(response, "기사 상태 변경이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success(response, "내 상태 변경이 완료되었습니다."));
     }
 }

--- a/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/InternalUserController.java
+++ b/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/InternalUserController.java
@@ -34,7 +34,7 @@ public class InternalUserController {
     private final GetInternalUserInfoUseCase getInternalUserInfoUseCase;
     private final GetAvailableDriversUseCase getAvailableDriversUseCase;
     
-    @Operation(summary = "사용자 정보 조회 (내부)", description = "서비스 간 통신을 위한 사용자 정보 조회")
+    @Operation(summary = "사용자 정보 조회 (내부)", description = "마이크로서비스 간 통신용 API. 특정 사용자(승객/기사/관리자)의 정보를 조회합니다. support-service 등에서 사용, 슬랙 알림용 데이터 포함.")
     @GetMapping("/users/{userId}")
     public ResponseEntity<InternalUserInfoResponse> getUserInfo(
             @PathVariable UUID userId) {
@@ -49,7 +49,7 @@ public class InternalUserController {
         return ResponseEntity.ok(response);
     }
     
-    @Operation(summary = "배차 가능한 기사 목록 조회", description = "픽업 주소 기반으로 대기중인 기사들의 정보를 조회")
+    @Operation(summary = "배차 가능한 기사 목록 조회", description = "마이크로서비스 간 통신용 API. 픽업 주소를 기반으로 온라인 상태인 기사들의 UUID 목록을 반환합니다. dispatch-service에서 사용, 더미 지역 매핑 적용.")
     @GetMapping("/drivers/available")
     public ResponseEntity<AvailableDriversResponse> getAvailableDrivers(
             @RequestParam String pickupAddress) {

--- a/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/UserController.java
+++ b/account-service/src/main/java/com/gooddaytaxi/account/adapter/web/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
     private final UpdateUserProfileUseCase updateUserProfileUseCase;
     private final DeleteUserUseCase deleteUserUseCase;
     
-    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자(승객/기사/관리자)의 프로필 정보를 조회합니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음")
@@ -53,7 +53,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(response, "내 정보 조회가 완료되었습니다."));
     }
     
-    @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자의 프로필 정보를 수정합니다")
+    @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자(승객/기사/관리자)의 기본 프로필 정보(이름, 전화번호)를 수정합니다")
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<UpdateUserProfileResponse>> updateMyProfile(
             @RequestHeader("X-User-UUID") String userUuidHeader,
@@ -69,7 +69,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(response, "내 정보 수정이 완료되었습니다."));
     }
     
-    @Operation(summary = "회원 탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다")
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인된 사용자(승객/기사/관리자)의 계정을 삭제합니다")
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<Void>> deleteMyAccount(
             @RequestHeader("X-User-UUID") String userUuidHeader) {

--- a/account-service/src/main/java/com/gooddaytaxi/account/presentation/controller/AuthController.java
+++ b/account-service/src/main/java/com/gooddaytaxi/account/presentation/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
     private final LoginUserUseCase loginUserUseCase;
     private final RefreshTokenUseCase refreshTokenUseCase;
 
-    @Operation(summary = "회원가입", description = "새 사용자를 등록합니다. 기사인 경우 차량 정보가 필수입니다.")
+    @Operation(summary = "회원가입", description = "새 사용자(승객/기사/관리자)를 등록합니다. 기사: 차량정보+슬랙ID 필수, 승객: 슬랙ID 필수, 관리자: 슬랙ID 불필요")
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         UserSignupCommand command = UserSignupCommand.builder()
@@ -63,7 +63,7 @@ public class AuthController {
                 .body(ApiResponse.success(response, "회원가입이 완료되었습니다."));
     }
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @Operation(summary = "로그인", description = "모든 사용자(승객/기사/관리자)가 이메일과 비밀번호로 로그인하여 JWT 토큰(액세스+리프레시)을 발급받습니다.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         UserLoginCommand command = new UserLoginCommand(request.getEmail(), request.getPassword());
@@ -74,7 +74,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(response, "로그인이 완료되었습니다."));
     }
 
-    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용해 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
+    @Operation(summary = "토큰 재발급", description = "모든 사용자가 리프레시 토큰을 사용해 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다. 토큰 만료 시 사용합니다.")
     @PostMapping("/refresh-token")
     public ResponseEntity<ApiResponse<RefreshTokenResponse>> refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
         RefreshTokenCommand command = new RefreshTokenCommand(request.getRefreshToken());


### PR DESCRIPTION
# 🚀 PR 개요 (PR Summary)

### PR 유형 (Choose One)
- [ ] ✨ feat: 기능 추가
- [ ] 🐞 fix: 버그 수정
- [x] 🛠️ refactor: 리팩터링
- [ ] 📚 docs: 문서 작업
- [ ] 🧹 chore: 설정/환경/빌드
- [ ] 🧪 test: 테스트 코드

### 관련 이슈
Closes #177 

### PR 목적
기사 API 설계를 /drivers/me 패턴으로 개선하고 Swagger 문서화를 강화하여 API 사용성을 향상

---

# 📝 변경 내용 (What’s Changed?)
  - 기사 프로필 수정 API: `PATCH /drivers/{driverId}` → `PATCH /drivers/me`
  - 기사 상태 변경 API: `PATCH /drivers/{driverId}/status` → `PATCH /drivers/me/status`
  - 모든 Controller API에 @Operation, @Tag 어노테이션 추가
  - Swagger 설명에 역할별 사용 가능 대상 명시 (승객/기사/관리자)

---

# 💡 구현 의도 & 설계 관점 (Why?)
 - **권한 체계 단순화**: Path Parameter + Header 조합에서 Header만 사용하도록 변경
  - **API 일관성**: UserController의 `/users/me` 패턴과 동일한 구조 적용
  - **보안 강화**: 본인만 수정 가능하도록 권한 로직 단순화
  - **프론트엔드 친화적**: 명확한 API 문서로 개발 효율성 향상
  - **RESTful 설계**: 자원 중심의 직관적인 URL 구조 적용

**Architecture 체크 (선택적)**
- Layer 규칙 위반 여부: (X)
- Aggregate 경계 위반 여부: (X)
- Module 간 cross import 여부: (X)

---

# ✅ 체크리스트 (Self Check)
- [X] CI 통과
- [X] 코드 스타일 준수 (불필요한 공백/주석 없음)
- [ ] 필요한 경우 테스트 코드 추가/수정

---

# 📣 공유 사항 (Communication)
필요한 경우만 체크하세요.

- [ ] 내부 통신(API/Event) 변경 있음
    - 변경 내용:
    - 팀 동기화 완료(O/X)

- [ ] API 응답 규칙 확인
    - [ ] 외부 API: `ApiResponse<T>`로 감쌈
    - [ ] 내부 API: DTO 자체를 반환  
